### PR TITLE
Add Observe Notifications.Task.DidCancel

### DIFF
--- a/Source/NetworkActivityIndicatorManager.swift
+++ b/Source/NetworkActivityIndicatorManager.swift
@@ -202,6 +202,13 @@ public class NetworkActivityIndicatorManager {
             name: Notifications.Task.DidComplete,
             object: nil
         )
+        
+        notificationCenter.addObserver(
+            self,
+            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidCancel),
+            name: Notifications.Task.DidCancel,
+            object: nil
+        )
     }
 
     private func unregisterForNotifications() {
@@ -215,6 +222,10 @@ public class NetworkActivityIndicatorManager {
     }
 
     @objc private func networkRequestDidComplete() {
+        decrementActivityCount()
+    }
+    
+    @objc private func networkRequestDidCancel() {
         decrementActivityCount()
     }
 


### PR DESCRIPTION
Is there any reason why DidCancel events don't hide the indicator?