### PR TITLE
Migrate to Swift 3

### DIFF
--- a/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
+++ b/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
@@ -237,7 +237,7 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0720;
-				LastUpgradeCheck = 0720;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = Alamofire;
 				TargetAttributes = {
 					4CB928381C66E1A600CE5F08 = {
@@ -504,6 +504,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.alamofire.AlamofireNetworkActivityIndicator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -526,6 +527,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
@@ -589,6 +591,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.alamofire.AlamofireNetworkActivityIndicator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 			};
 			name = ReleaseTest;
@@ -600,6 +603,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 3.0;
 			};
 			name = ReleaseTest;

--- a/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
+++ b/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
@@ -242,9 +242,11 @@
 				TargetAttributes = {
 					4CB928381C66E1A600CE5F08 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 					4CB928421C66E1A700CE5F08 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -481,6 +483,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -501,6 +504,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.alamofire.AlamofireNetworkActivityIndicator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -511,6 +515,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -521,6 +526,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -583,6 +589,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.alamofire.AlamofireNetworkActivityIndicator;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = ReleaseTest;
 		};
@@ -593,6 +600,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = ReleaseTest;
 		};

--- a/AlamofireNetworkActivityIndicator.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityIndicator.xcscheme
+++ b/AlamofireNetworkActivityIndicator.xcodeproj/xcshareddata/xcschemes/AlamofireNetworkActivityIndicator.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0720"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" ~> 3.3
+github "Alamofire/Alamofire" "swift3"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "3.3.0"
+github "Alamofire/Alamofire" "fcb4829a78d28e3491c6767cfb74e774871943b0"

--- a/Tests/NetworkActivityIndicatorManagerTests.swift
+++ b/Tests/NetworkActivityIndicatorManagerTests.swift
@@ -36,7 +36,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         manager.startDelay = 0.0
         manager.completionDelay = 0.0
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
 
         var visibilityStates: [Bool] = []
 
@@ -48,7 +48,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         // When
         manager.incrementActivityCount()
         dispatch_after(0.1) { manager.decrementActivityCount() }
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertTrue(manager.isEnabled)
@@ -66,7 +66,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         manager.startDelay = 0.0
         manager.completionDelay = 0.0
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
 
         var visibilityStates: [Bool] = []
 
@@ -81,7 +81,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         dispatch_after(0.10) { manager.decrementActivityCount() }
         dispatch_after(0.15) { manager.decrementActivityCount() }
 
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertTrue(manager.isEnabled)
@@ -108,10 +108,10 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         manager.incrementActivityCount()
         dispatch_after(0.05) { manager.decrementActivityCount() }
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
         dispatch_after(0.1) { expectation.fulfill() }
 
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertTrue(manager.isEnabled)
@@ -124,7 +124,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         manager.startDelay = 0.0
         manager.completionDelay = 0.2
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
 
         var visibilityStates: [Bool] = []
 
@@ -139,7 +139,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         dispatch_after(0.2) { manager.incrementActivityCount() }
         dispatch_after(0.3) { manager.decrementActivityCount() }
 
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertTrue(manager.isEnabled)
@@ -168,10 +168,10 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         manager.incrementActivityCount()
         dispatch_after(0.1) { manager.decrementActivityCount() }
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
         dispatch_after(0.2) { expectation.fulfill() }
 
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertFalse(manager.isEnabled)
@@ -196,10 +196,10 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         dispatch_after(0.15) { manager.decrementActivityCount() }
         dispatch_after(0.20) { manager.decrementActivityCount() }
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
         dispatch_after(0.25) { expectation.fulfill() }
 
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertTrue(manager.isEnabled)
@@ -219,7 +219,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         manager.startDelay = 0.0
         manager.completionDelay = 0.0
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
 
         var visibilityStates: [Bool] = []
 
@@ -229,8 +229,8 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        Alamofire.request(.GET, "https://httpbin.org/delay/1")
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        let _ = Alamofire.request(.GET, "https://httpbin.org/delay/1")
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(visibilityStates.count, 2)
@@ -247,7 +247,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         manager.startDelay = 0.0
         manager.completionDelay = 0.0
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
 
         var visibilityStates: [Bool] = []
 
@@ -257,8 +257,8 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        Alamofire.request(.GET, "https://httpbin.org/status/404")
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        let _ = Alamofire.request(.GET, "https://httpbin.org/status/404")
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(visibilityStates.count, 2)
@@ -275,7 +275,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         manager.startDelay = 1.0
         manager.completionDelay = 1.0
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
 
         var visibilityStates: [Bool] = []
 
@@ -285,8 +285,8 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        Alamofire.request(.GET, "https://httpbin.org/delay/2")
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        let _ = Alamofire.request(.GET, "https://httpbin.org/delay/2")
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(visibilityStates.count, 2)
@@ -303,7 +303,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         manager.startDelay = 0.5
         manager.completionDelay = 0.5
 
-        let expectation = expectationWithDescription("visibility should change twice")
+        let expectation = self.expectation(description: "visibility should change twice")
 
         var visibilityStates: [Bool] = []
 
@@ -313,11 +313,11 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        Alamofire.request(.GET, "https://httpbin.org/delay/1")
-        Alamofire.request(.GET, "https://httpbin.org/delay/2")
-        Alamofire.request(.GET, "https://httpbin.org/delay/3")
+        let _ = Alamofire.request(.GET, "https://httpbin.org/delay/1")
+        let _ = Alamofire.request(.GET, "https://httpbin.org/delay/2")
+        let _ = Alamofire.request(.GET, "https://httpbin.org/delay/3")
 
-        waitForExpectationsWithTimeout(timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
         XCTAssertEqual(visibilityStates.count, 2)
@@ -332,10 +332,10 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
 // MARK: -
 
 private func dispatch_after(
-    seconds: NSTimeInterval,
-    _ queue: dispatch_queue_t = dispatch_get_main_queue(),
-    _ closure: dispatch_block_t)
+    _ seconds: TimeInterval,
+    _ queue: DispatchQueue = DispatchQueue.main,
+    _ closure: () -> ())
 {
-    let time = dispatch_time(DISPATCH_TIME_NOW, Int64(ceil(seconds * NSTimeInterval(NSEC_PER_SEC))))
-    dispatch_after(time, queue) { closure() }
+    let time = DispatchTime.now() + seconds
+    queue.after(when: time) { closure() }
 }


### PR DESCRIPTION
This PR migrates the project to Swift 3 with Xcode 8 beta 3.

* Migrates framework source to Swift 3
* Migrates test source to Swift 3
* Turns on whole module optimization for release builds
* Updates Alamofire dependency to Swift 3 compatible version

On my machine all tests are passing. They will fail on Travis as there is no Xcode 8 beta 3 on Travis yet. 
I don't expect this to be merged into master. It would be great if we could create a branch `swift3` similar to Alamofire or AlamofireImage. I will gladly resubmit the PR.