### PR TITLE
Updates the deployment target in the podspec file to match the project file

### DIFF
--- a/AlamofireNetworkActivityIndicator.podspec
+++ b/AlamofireNetworkActivityIndicator.podspec
@@ -12,5 +12,5 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '9.0'
 
-  s.dependency 'Alamofire', '4.0.0-beta.1'
+  s.dependency 'Alamofire', '4.0.0-beta.2'
 end

--- a/AlamofireNetworkActivityIndicator.podspec
+++ b/AlamofireNetworkActivityIndicator.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/Alamofire/AlamofireNetworkActivityIndicator.git', :tag => s.version }
   s.source_files = 'Source/*.swift'
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '9.0'
 
   s.dependency 'Alamofire', '4.0.0-beta.1'
 end

--- a/AlamofireNetworkActivityIndicator.podspec
+++ b/AlamofireNetworkActivityIndicator.podspec
@@ -10,7 +10,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/Alamofire/AlamofireNetworkActivityIndicator.git', :tag => s.version }
   s.source_files = 'Source/*.swift'
 
-  s.ios.deployment_target = '9.0'
+  s.ios.deployment_target = '10.0'
 
   s.dependency 'Alamofire', '4.0.0-beta.2'
 end


### PR DESCRIPTION
## What this does
This fixes a compilation issue using the latest from the `swift3` branch, targetting the latest version of `Alamofire` (swift3 branch again). The project file has a deployment target os iOS 9.0 but the podspec file has a deployment target of 8.0. This updates the podspec file to match that.