### PR TITLE
Update README with Embedded Framework instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,42 @@ To integrate AlamofireNetworkActivityIndicator into your Xcode project using Car
 github "Alamofire/AlamofireNetworkActivityIndicator" ~> 2.0
 ```
 
+### Manually
+
+If you prefer not to use either of the aforementioned dependency managers, you can integrate AlamofireNetworkActivityIndicator into your project manually.
+
+#### Embedded Framework
+
+- Open up Terminal, `cd` into your top-level project directory, and run the following command "if" your project is not initialized as a git repository:
+
+  ```bash
+$ git init
+```
+
+- Add AlamofireNetworkActivityIndicator as a git [submodule](http://git-scm.com/docs/git-submodule) by running the following command:
+
+  ```bash
+$ git submodule add https://github.com/Alamofire/AlamofireNetworkActivityIndicator.git
+```
+
+- Open the new `AlamofireNetworkActivityIndicator` folder, and drag the `AlamofireNetworkActivityIndicator.xcodeproj` into the Project Navigator of your application's Xcode project.
+
+    > It should appear nested underneath your application's blue project icon. Whether it is above or below all the other Xcode groups does not matter.
+
+- Select the `AlamofireNetworkActivityIndicator.xcodeproj` in the Project Navigator and verify the deployment target matches that of your application target.
+- Next, select your application project in the Project Navigator (blue project icon) to navigate to the target configuration window and select the application target under the "Targets" heading in the sidebar.
+- In the tab bar at the top of that window, open the "General" panel.
+- Click on the `+` button under the "Embedded Binaries" section.
+- You will see two different `AlamofireNetworkActivityIndicator.xcodeproj` folders each with two different versions of the `AlamofireNetworkActivityIndicator.framework` nested inside a `Products` folder.
+
+    > It does not matter which `Products` folder you choose from.
+
+- Select the `AlamofireNetworkActivityIndicator.framework` and add it to your project.
+
+- And that's it!
+
+  > The `AlamofireNetworkActivityIndicator.framework` is automagically added as a target dependency, linked framework and embedded framework in a copy files build phase which is all you need to build on the simulator and a device.
+
 ---
 
 ## Usage


### PR DESCRIPTION
Added Git Submodule install instructions.
Same as AlamofireImage, the git submodule installation instructions were missing. 

By the way, a BIG thank your for maintaining these awesome projects!