### PR TITLE
Remove BITCODE_GENERATION_MODE

### DIFF
--- a/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
+++ b/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
@@ -578,7 +578,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
-				BITCODE_GENERATION_MODE = marker;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -600,7 +599,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = NO;
-				BITCODE_GENERATION_MODE = bitcode;
 				CLANG_ENABLE_MODULES = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;


### PR DESCRIPTION
### Goals :soccer:
Remove `BITCODE_GENERATION_MODE` settings which leads to make binary always bitcode even target to device.

### Implementation Details :construction:
If this project is added as subproject to other project, this project generate bitcode ALWAYS which should not be happened when build target to device directly. (for running on it)

And more that, Alamofire project build correctly as is, so these error occurs while linking `AlamofireNetworkActivityIndicator`:
```
ld: bitcode bundle could not be generated because '<Alamofire Framework Binary Path>' was built without full bitcode. All frameworks and dylibs for bitcode must be generated from Xcode Archive or Install build file '<Alamofire Framework Binary Path>' for architecture armv7
```

### Testing Details :mag:
I tested it through embed as subproject, and carthage build.