### PR TITLE
Swift 4.2

### DIFF
--- a/AlamofireNetworkActivityIndicator.podspec
+++ b/AlamofireNetworkActivityIndicator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'AlamofireNetworkActivityIndicator'
-  s.version = '2.2.1'
+  s.version = '2.2.2'
   s.license = 'MIT'
   s.summary = 'Controls the visibility of the network activity indicator on iOS using Alamofire'
   s.homepage = 'https://github.com/Alamofire/AlamofireNetworkActivityIndicator'

--- a/Source/NetworkActivityIndicatorManager.swift
+++ b/Source/NetworkActivityIndicatorManager.swift
@@ -223,8 +223,13 @@ public class NetworkActivityIndicatorManager {
         )
 
         DispatchQueue.main.async {
+            #if swift(>=4.2)
+            RunLoop.main.add(timer, forMode: .common)
+            RunLoop.main.add(timer, forMode: .tracking)
+            #else
             RunLoop.main.add(timer, forMode: .commonModes)
             RunLoop.main.add(timer, forMode: .UITrackingRunLoopMode)
+            #endif
         }
 
         startDelayTimer = timer
@@ -240,8 +245,13 @@ public class NetworkActivityIndicatorManager {
         )
 
         DispatchQueue.main.async {
+            #if swift(>=4.2)
+            RunLoop.main.add(timer, forMode: .common)
+            RunLoop.main.add(timer, forMode: .tracking)
+            #else
             RunLoop.main.add(timer, forMode: .commonModes)
             RunLoop.main.add(timer, forMode: .UITrackingRunLoopMode)
+            #endif
         }
 
         completionDelayTimer = timer


### PR DESCRIPTION
### Issue Link :link:
Apple renamed `RunLoop.Mode` in Swift 4.2, which broke compilation. Xcode 10 and Swift 4.2 are out now, so I thought I'd open a PR.

### Goals :soccer:
Swift 4.2 support.

### Implementation Details :construction:
Added a simple `#if swift(>=4.2)` block around the relevant code.
Also incremented the podspec version.

### Testing Details :mag:
@jshier I noticed you had your [own branch](https://github.com/Alamofire/AlamofireNetworkActivityIndicator/compare/swift4.2) where you were also tweaking some tests and playing around with the Alamofire version - wasn't sure about that but figured I should leave that out...?