### PR TITLE
Migrate to swift 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode9.4
+osx_image: xcode10.2
 branches:
   only:
     - master
@@ -10,6 +10,7 @@ env:
   - PROJECT=AlamofireNetworkActivityIndicator.xcodeproj
   - SCHEME="AlamofireNetworkActivityIndicator"
   matrix:
+    - DESTINATION="OS=12.2,name=iPhone XS"   POD_LINT="YES"
     - DESTINATION="OS=11.4,name=iPhone X"    POD_LINT="YES"
     - DESTINATION="OS=10.3.1,name=iPhone 7"  POD_LINT="NO"
     - DESTINATION="OS=9.3,name=iPhone 6"     POD_LINT="NO"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode10.2
+osx_image: xcode9.4
 branches:
   only:
     - master
@@ -10,7 +10,6 @@ env:
   - PROJECT=AlamofireNetworkActivityIndicator.xcodeproj
   - SCHEME="AlamofireNetworkActivityIndicator"
   matrix:
-    - DESTINATION="OS=12.2,name=iPhone XS"   POD_LINT="YES"
     - DESTINATION="OS=11.4,name=iPhone X"    POD_LINT="YES"
     - DESTINATION="OS=10.3.1,name=iPhone 7"  POD_LINT="NO"
     - DESTINATION="OS=9.3,name=iPhone 6"     POD_LINT="NO"

--- a/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
+++ b/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
@@ -507,7 +507,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -564,7 +564,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -592,7 +592,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -614,7 +614,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};
@@ -626,7 +626,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
 		};
@@ -639,7 +639,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.2;
+				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
 		};

--- a/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
+++ b/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
@@ -592,7 +592,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = "";
 			};
 			name = Debug;
 		};
@@ -614,7 +614,7 @@
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = "";
 			};
 			name = Release;
 		};
@@ -626,7 +626,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = "";
 			};
 			name = Debug;
 		};
@@ -639,7 +639,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = 4.0;
+				SWIFT_VERSION = "";
 			};
 			name = Release;
 		};

--- a/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
+++ b/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
@@ -591,8 +591,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = "";
 			};
 			name = Debug;
 		};
@@ -613,8 +611,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = "";
 			};
 			name = Release;
 		};
@@ -625,8 +621,6 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = "";
 			};
 			name = Debug;
 		};
@@ -638,8 +632,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
-				SWIFT_VERSION = "";
 			};
 			name = Release;
 		};

--- a/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
+++ b/AlamofireNetworkActivityIndicator.xcodeproj/project.pbxproj
@@ -285,12 +285,12 @@
 					};
 					4CB928381C66E1A600CE5F08 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1010;
 						ProvisioningStyle = Automatic;
 					};
 					4CB928421C66E1A700CE5F08 = {
 						CreatedOnToolsVersion = 7.2;
-						LastSwiftMigration = 0900;
+						LastSwiftMigration = 1010;
 					};
 				};
 			};
@@ -507,7 +507,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -564,7 +564,7 @@
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
-				SWIFT_VERSION = 3.0;
+				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				TVOS_DEPLOYMENT_TARGET = 9.0;
 				VALIDATE_PRODUCT = YES;
@@ -591,7 +591,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -612,7 +613,8 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -623,7 +625,8 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
 		};
@@ -635,7 +638,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = org.alamofire.AlamofireNetworkActivityIndicatorTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_SWIFT3_OBJC_INFERENCE = Off;
+				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" ~> 4.7
+github "Alamofire/Alamofire" ~> 4.8

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "4.7.3"
+github "Alamofire/Alamofire" "4.8.1"

--- a/README.md
+++ b/README.md
@@ -18,13 +18,13 @@ Controls the visibility of the network activity indicator on iOS using Alamofire
 
 ## Requirements
 
-- iOS 10.0+
-- Xcode 10.1+
-- Swift 4.2+
+- iOS 8.0+
+- Xcode 9.0+
+- Swift 4.0+
 
 ## Dependencies
 
-- [Alamofire 4.7+](https://github.com/Alamofire/Alamofire)
+- [Alamofire 4.8+](https://github.com/Alamofire/Alamofire)
 
 ## Communication
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Controls the visibility of the network activity indicator on iOS using Alamofire
 
 ## Requirements
 
-- iOS 8.0+
-- Xcode 8.1+
-- Swift 3.0+
+- iOS 10.0+
+- Xcode 10.1+
+- Swift 4.2+
 
 ## Dependencies
 

--- a/Source/NetworkActivityIndicatorManager.swift
+++ b/Source/NetworkActivityIndicatorManager.swift
@@ -223,8 +223,13 @@ public class NetworkActivityIndicatorManager {
         )
 
         DispatchQueue.main.async {
+            #if swift(>=4.2)
             RunLoop.main.add(timer, forMode: .common)
             RunLoop.main.add(timer, forMode: .tracking)
+            #else
+            RunLoop.main.add(timer, forMode: .commonModes)
+            RunLoop.main.add(timer, forMode: .UITrackingRunLoopMode)
+            #endif
         }
 
         startDelayTimer = timer
@@ -240,8 +245,13 @@ public class NetworkActivityIndicatorManager {
         )
 
         DispatchQueue.main.async {
+            #if swift(>=4.2)
             RunLoop.main.add(timer, forMode: .common)
             RunLoop.main.add(timer, forMode: .tracking)
+            #else
+            RunLoop.main.add(timer, forMode: .commonModes)
+            RunLoop.main.add(timer, forMode: .UITrackingRunLoopMode)
+            #endif
         }
 
         completionDelayTimer = timer

--- a/Source/NetworkActivityIndicatorManager.swift
+++ b/Source/NetworkActivityIndicatorManager.swift
@@ -223,13 +223,8 @@ public class NetworkActivityIndicatorManager {
         )
 
         DispatchQueue.main.async {
-            #if swift(>=4.2)
             RunLoop.main.add(timer, forMode: .common)
             RunLoop.main.add(timer, forMode: .tracking)
-            #else
-            RunLoop.main.add(timer, forMode: .commonModes)
-            RunLoop.main.add(timer, forMode: .UITrackingRunLoopMode)
-            #endif
         }
 
         startDelayTimer = timer
@@ -245,13 +240,8 @@ public class NetworkActivityIndicatorManager {
         )
 
         DispatchQueue.main.async {
-            #if swift(>=4.2)
             RunLoop.main.add(timer, forMode: .common)
             RunLoop.main.add(timer, forMode: .tracking)
-            #else
-            RunLoop.main.add(timer, forMode: .commonModes)
-            RunLoop.main.add(timer, forMode: .UITrackingRunLoopMode)
-            #endif
         }
 
         completionDelayTimer = timer


### PR DESCRIPTION
### Issue Link :link:
This fixes #43 where building with Carthage on Xcode 10.2 was failing due to Swift 3 being deprecated.

### Goals :soccer:
- Allow using AlamofireNetworkActivityIndicator with Xcode 10.2.

### Implementation Details :construction:
- All targets had their Swift version updated from 3.0 to 4.0.
- Updated README.md for bumped requirements.

### Testing Details :mag:
No changes made to testing due to Travis not having an xcode10.2 official release image available yet. Would be good to add an iOS 12.2 simulator to tests and build against Xcode 10.2 in the future once the image is available.