### PR TITLE
Compatibility with Alamofire 5 beta 3

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "alamofire5"
+github "Alamofire/Alamofire" ~> 5.0.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "a8a2827f5c14c9168a0373e948e963d36edfdbc5"
+github "Alamofire/Alamofire" "5.0.0.beta.1"

--- a/Source/NetworkActivityIndicatorManager.swift
+++ b/Source/NetworkActivityIndicatorManager.swift
@@ -178,21 +178,21 @@ public class NetworkActivityIndicatorManager {
         notificationCenter.addObserver(
             self,
             selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStart),
-            name: .afDidResume,
+            name: Request.didResume,
             object: nil
         )
 
         notificationCenter.addObserver(
             self,
             selector: #selector(NetworkActivityIndicatorManager.networkRequestDidComplete),
-            name: .afDidSuspend,
+            name: Request.didSuspend,
             object: nil
         )
 
         notificationCenter.addObserver(
             self,
             selector: #selector(NetworkActivityIndicatorManager.networkRequestDidComplete),
-            name: .afDidComplete,
+            name: Request.didComplete,
             object: nil
         )
     }


### PR DESCRIPTION
### Goals :soccer:
- Ensure compatibility with beta 3 of Alamofire 5

### Implementation Details :construction:
- Carthage points to the latest beta of Alamofire 5
- Uses the new notification names found on the [Request type in Alamofire](https://github.com/Alamofire/Alamofire/blob/master/Source/Notifications.swift#L27-L36)