### PR TITLE
Feature - Request Tracking

### DIFF
--- a/Source/NetworkActivityIndicatorManager.swift
+++ b/Source/NetworkActivityIndicatorManager.swift
@@ -1,7 +1,7 @@
 //
 //  NetworkActivityIndicatorManager.swift
 //
-//  Copyright (c) 2016-2018 Alamofire Software Foundation (http://alamofire.org/)
+//  Copyright (c) 2016 Alamofire Software Foundation (http://alamofire.org/)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -87,6 +87,8 @@ public class NetworkActivityIndicatorManager {
 
     private var activityIndicatorState: ActivityIndicatorState = .notActive {
         didSet {
+            lock.lock() ; defer { lock.unlock() }
+
             switch activityIndicatorState {
             case .notActive:
                 isNetworkActivityIndicatorVisible = false
@@ -103,13 +105,13 @@ public class NetworkActivityIndicatorManager {
         }
     }
 
-    private var activityCount: Int = 0
+    private var requestIDs: Set<String> = []
     private var enabled: Bool = true
 
     private var startDelayTimer: Timer?
     private var completionDelayTimer: Timer?
 
-    private let lock = NSLock()
+    private let lock = NSRecursiveLock()
 
     // MARK: - Internal - Initialization
 
@@ -124,31 +126,29 @@ public class NetworkActivityIndicatorManager {
         invalidateCompletionDelayTimer()
     }
 
-    // MARK: - Activity Count
+    // MARK: - Request Tracking
 
-    /// Increments the number of active network requests.
+    /// Adds the requestID as an active request driving the activity indicator.
     ///
-    /// If this number was zero before incrementing, the network activity indicator will start spinning after
-    /// the `startDelay`.
+    /// This method results in a no-op if the request is already being tracked.
     ///
-    /// Generally, this method should not need to be used directly.
-    public func incrementActivityCount() {
+    /// - Parameter requestID: The request identifier.
+    public func requestDidStart(requestID: String) {
         lock.lock() ; defer { lock.unlock() }
 
-        activityCount += 1
+        requestIDs.insert(requestID)
         updateActivityIndicatorStateForNetworkActivityChange()
     }
 
-    /// Decrements the number of active network requests.
+    /// Removes the requestID from the set of active requests driving the activity indicator.
     ///
-    /// If the number of active requests is zero after calling this method, the network activity indicator will stop
-    /// spinning after the `completionDelay`.
+    /// This method results in a no-op if the request is not being tracked.
     ///
-    /// Generally, this method should not need to be used directly.
-    public func decrementActivityCount() {
+    /// - Parameter requestID: The request identifier.
+    public func requestDidStop(requestID: String) {
         lock.lock() ; defer { lock.unlock() }
 
-        activityCount -= 1
+        requestIDs.remove(requestID)
         updateActivityIndicatorStateForNetworkActivityChange()
     }
 
@@ -159,14 +159,14 @@ public class NetworkActivityIndicatorManager {
 
         switch activityIndicatorState {
         case .notActive:
-            if activityCount > 0 { activityIndicatorState = .delayingStart }
+            if !requestIDs.isEmpty { activityIndicatorState = .delayingStart }
         case .delayingStart:
             // No-op - let the delay timer finish
             break
         case .active:
-            if activityCount == 0 { activityIndicatorState = .delayingCompletion }
+            if requestIDs.isEmpty { activityIndicatorState = .delayingCompletion }
         case .delayingCompletion:
-            if activityCount > 0 { activityIndicatorState = .active }
+            if !requestIDs.isEmpty { activityIndicatorState = .active }
         }
     }
 
@@ -177,21 +177,21 @@ public class NetworkActivityIndicatorManager {
 
         notificationCenter.addObserver(
             self,
-            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStart),
+            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStart(notification:)),
             name: Request.didResume,
             object: nil
         )
 
         notificationCenter.addObserver(
             self,
-            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidComplete),
+            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStop(notification:)),
             name: Request.didSuspend,
             object: nil
         )
 
         notificationCenter.addObserver(
             self,
-            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidComplete),
+            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStop(notification:)),
             name: Request.didFinish,
             object: nil
         )
@@ -203,12 +203,14 @@ public class NetworkActivityIndicatorManager {
 
     // MARK: - Private - Notifications
 
-    @objc private func networkRequestDidStart() {
-        incrementActivityCount()
+    @objc private func networkRequestDidStart(notification: Notification) {
+        guard let request = notification.request else { return }
+        requestDidStart(requestID: request.id.uuidString)
     }
 
-    @objc private func networkRequestDidComplete() {
-        decrementActivityCount()
+    @objc private func networkRequestDidStop(notification: Notification) {
+        guard let request = notification.request else { return }
+        requestDidStop(requestID: request.id.uuidString)
     }
 
     // MARK: - Private - Timers
@@ -250,7 +252,7 @@ public class NetworkActivityIndicatorManager {
     @objc private func startDelayTimerFired() {
         lock.lock() ; defer { lock.unlock() }
 
-        if activityCount > 0 {
+        if !requestIDs.isEmpty {
             activityIndicatorState = .active
         } else {
             activityIndicatorState = .notActive

--- a/Source/NetworkActivityIndicatorManager.swift
+++ b/Source/NetworkActivityIndicatorManager.swift
@@ -177,21 +177,21 @@ public class NetworkActivityIndicatorManager {
 
         notificationCenter.addObserver(
             self,
-            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStart(notification:)),
+            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStart),
             name: Request.didResume,
             object: nil
         )
 
         notificationCenter.addObserver(
             self,
-            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStop(notification:)),
+            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStop),
             name: Request.didSuspend,
             object: nil
         )
 
         notificationCenter.addObserver(
             self,
-            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStop(notification:)),
+            selector: #selector(NetworkActivityIndicatorManager.networkRequestDidStop),
             name: Request.didFinish,
             object: nil
         )

--- a/Source/NetworkActivityIndicatorManager.swift
+++ b/Source/NetworkActivityIndicatorManager.swift
@@ -87,8 +87,6 @@ public class NetworkActivityIndicatorManager {
 
     private var activityIndicatorState: ActivityIndicatorState = .notActive {
         didSet {
-            lock.lock() ; defer { lock.unlock() }
-
             switch activityIndicatorState {
             case .notActive:
                 isNetworkActivityIndicatorVisible = false

--- a/Tests/NetworkActivityIndicatorManagerTests.swift
+++ b/Tests/NetworkActivityIndicatorManagerTests.swift
@@ -1,7 +1,7 @@
 //
 //  NetworkActivityIndicatorManagerTests.swift
 //
-//  Copyright (c) 2016-2018 Alamofire Software Foundation (http://alamofire.org/)
+//  Copyright (c) 2016 Alamofire Software Foundation (http://alamofire.org/)
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -30,9 +30,9 @@ import XCTest
 class NetworkActivityIndicatorManagerTestCase: XCTestCase {
     let timeout = 10.0
 
-    // MARK: - Tests - Manual Activity Count Updates
+    // MARK: - Tests - Manual Request Tracking
 
-    func testThatManagerCanTurnOnAndOffIndicatorWhenManuallyIncrementingAndDecrementingActivityCount() {
+    func testThatManagerCanTurnOnAndOffIndicatorWhenManuallyControllingRequests() {
         // Given
         let manager = NetworkActivityIndicatorManager()
         manager.startDelay = 0.0
@@ -48,8 +48,8 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        manager.incrementActivityCount()
-        dispatchAfter(0.1) { manager.decrementActivityCount() }
+        manager.requestDidStart(requestID: "r1")
+        dispatchAfter(0.1) { manager.requestDidStop(requestID: "r1") }
         waitForExpectations(timeout: timeout, handler: nil)
 
         // Then
@@ -62,7 +62,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
     }
 
-    func testThatManagerCanTurnOnAndOffIndicatorWhenManuallyControllingActivityCountWithMultipleChanges() {
+    func testThatManagerCanTurnOnAndOffIndicatorWhenManuallyControllingRequestsWithMultipleChanges() {
         // Given
         let manager = NetworkActivityIndicatorManager()
         manager.startDelay = 0.0
@@ -78,10 +78,10 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        manager.incrementActivityCount()
-        dispatchAfter(0.05) { manager.incrementActivityCount() }
-        dispatchAfter(0.10) { manager.decrementActivityCount() }
-        dispatchAfter(0.15) { manager.decrementActivityCount() }
+        manager.requestDidStart(requestID: "r1")
+        dispatchAfter(0.05) { manager.requestDidStart(requestID: "r2") }
+        dispatchAfter(0.10) { manager.requestDidStop(requestID: "r1") }
+        dispatchAfter(0.15) { manager.requestDidStop(requestID: "r2") }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -95,7 +95,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
     }
 
-    func testThatManagerAppliesStartDelayWhenManuallyControllingActivityCount() {
+    func testThatManagerAppliesStartDelayWhenManuallyControllingRequests() {
         // Given
         let manager = NetworkActivityIndicatorManager()
         manager.startDelay = 0.125
@@ -107,8 +107,8 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        manager.incrementActivityCount()
-        dispatchAfter(0.05) { manager.decrementActivityCount() }
+        manager.requestDidStart(requestID: "r1")
+        dispatchAfter(0.05) { manager.requestDidStop(requestID: "r1") }
 
         let expectation = self.expectation(description: "visibility should change twice")
         dispatchAfter(0.25) { expectation.fulfill() }
@@ -120,7 +120,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         XCTAssertTrue(visibilityStates.isEmpty)
     }
 
-    func testThatManagerAppliesFinishDelayWhenManuallyControllingActivityCount() {
+    func testThatManagerAppliesFinishDelayWhenManuallyControllingRequests() {
         // Given
         let manager = NetworkActivityIndicatorManager()
         manager.startDelay = 0.0
@@ -136,10 +136,10 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        manager.incrementActivityCount()
-        dispatchAfter(0.1) { manager.decrementActivityCount() }
-        dispatchAfter(0.2) { manager.incrementActivityCount() }
-        dispatchAfter(0.3) { manager.decrementActivityCount() }
+        manager.requestDidStart(requestID: "r1")
+        dispatchAfter(0.1) { manager.requestDidStop(requestID: "r1") }
+        dispatchAfter(0.2) { manager.requestDidStart(requestID: "r2") }
+        dispatchAfter(0.3) { manager.requestDidStop(requestID: "r2") }
 
         waitForExpectations(timeout: timeout, handler: nil)
 
@@ -167,8 +167,8 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        manager.incrementActivityCount()
-        dispatchAfter(0.1) { manager.decrementActivityCount() }
+        manager.requestDidStart(requestID: "r1")
+        dispatchAfter(0.1) { manager.requestDidStop(requestID: "r1") }
 
         let expectation = self.expectation(description: "visibility should change twice")
         dispatchAfter(0.2) { expectation.fulfill() }
@@ -180,7 +180,7 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         XCTAssertTrue(visibilityStates.isEmpty)
     }
 
-    func testThatManagerIgnoresDecrementingActivityCountWhenAlreadyZero() {
+    func testThatManagerIgnoresDuplicateRequestDidStartCalls() {
         // Given
         let manager = NetworkActivityIndicatorManager()
         manager.startDelay = 0.0
@@ -193,10 +193,43 @@ class NetworkActivityIndicatorManagerTestCase: XCTestCase {
         }
 
         // When
-        manager.incrementActivityCount()
-        dispatchAfter(0.10) { manager.decrementActivityCount() }
-        dispatchAfter(0.15) { manager.decrementActivityCount() }
-        dispatchAfter(0.20) { manager.decrementActivityCount() }
+        manager.requestDidStart(requestID: "r1")
+        dispatchAfter(0.10) { manager.requestDidStart(requestID: "r1") }
+        dispatchAfter(0.15) { manager.requestDidStart(requestID: "r1") }
+        dispatchAfter(0.20) { manager.requestDidStop(requestID: "r1") }
+
+        let expectation = self.expectation(description: "visibility should change twice")
+        dispatchAfter(0.25) { expectation.fulfill() }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertTrue(manager.isEnabled)
+        XCTAssertEqual(visibilityStates.count, 2)
+
+        if visibilityStates.count == 2 {
+            XCTAssertTrue(visibilityStates[0])
+            XCTAssertFalse(visibilityStates[1])
+        }
+    }
+
+    func testThatManagerIgnoresDuplicateRequestDidStopCalls() {
+        // Given
+        let manager = NetworkActivityIndicatorManager()
+        manager.startDelay = 0.0
+        manager.completionDelay = 0.0
+
+        var visibilityStates: [Bool] = []
+
+        manager.networkActivityIndicatorVisibilityChanged = { isVisible in
+            visibilityStates.append(isVisible)
+        }
+
+        // When
+        manager.requestDidStart(requestID: "r1")
+        dispatchAfter(0.10) { manager.requestDidStop(requestID: "r1") }
+        dispatchAfter(0.15) { manager.requestDidStop(requestID: "r1") }
+        dispatchAfter(0.20) { manager.requestDidStop(requestID: "r1") }
 
         let expectation = self.expectation(description: "visibility should change twice")
         dispatchAfter(0.25) { expectation.fulfill() }


### PR DESCRIPTION
This PR refactors the fragile activity counting to a more robust request id tracking system.

### Issue Link :link:
#38 

### Goals :soccer:
The goals of this PR are to:
- Fix issue #38
- Create a better public API that does not rely on a single counter

### Implementation Details :construction:
The original implementation relied on an activity counter that would run the activity indicator when the count was greater than zero. This proved to be too fragile with mismatches between resume, suspend, and complete calls as well as the public APIs for controlling the count.

This PR switches away from using a single counter to instead tracking active request through a set of `String` requestIDs. I chose to go with a `Set<String>` instead of `Set<UUID>` because other clients generating requests may not be generating UUIDs alongside them. I thought it would make it easier for them to adopt if we used `String` identifiers instead.

### Testing Details :mag:
I've updated the test suite to test all the new edge cases with the new APIs.