### PR TITLE
Fix Carthage installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ pod 'AlamofireNetworkActivityIndicator', '~> 2.4'
 [Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks. To integrate Alamofire into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "AlamofireNetworkActivityIndicator" "~> 2.4"
+github "Alamofire/AlamofireNetworkActivityIndicator" ~> 2.4.0
 ```
 
 ### Manually


### PR DESCRIPTION
Hi everyone!

I was having problems following your Carthage installation instructions and noticed that the syntax of the line that should be added to Cartfile was missing the GitHub user name (Alamofire) and the version number didn't need the double quotes around them.

I'm using Carthage 0.32.0.