### PR TITLE
remove "beta.2" from CFBundleShortVersionString key in info.plist

### DIFF
--- a/Source/Info.plist
+++ b/Source/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.0.0.beta.2</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
update CFBundleShortVersionString in order to remove the string ".beta.2" left in in it, distributing the app is not possible with a string it it. left in in it, distributing the app is not possible with a string it it.

This PR drops the pre-release version from the CFBundleShortVersionString in the Info.plist.

Goals ⚽️

To allow users to be able to submit AlamofireNetworkActivityIndicator betas to the AppStore using submodules and Carthage.

Implementation Details 🚧

N/A

Testing Details 🔍

N/A