### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.1
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
         .library(name: "AlamofireNetworkActivityIndicator", targets: ["AlamofireNetworkActivityIndicator"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0-beta.6")
+        .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0-rc.3")
     ],
     targets: [
         .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,20 @@
+// swift-tools-version:5.0
+import PackageDescription
+
+let package = Package(
+    name: "AlamofireNetworkActivityIndicator",
+    platforms: [.iOS(.v10)],
+    products: [
+        .library(name: "AlamofireNetworkActivityIndicator", targets: ["AlamofireNetworkActivityIndicator"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0-beta.6")
+    ],
+    targets: [
+        .target(
+            name: "AlamofireNetworkActivityIndicator",
+            dependencies: ["Alamofire"],
+            path: "Source"
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ pod 'AlamofireNetworkActivityIndicator', '~> 2.4'
 github "Alamofire/AlamofireNetworkActivityIndicator" ~> 2.4.0
 ```
 
+### Swift Package Manager (required Xcode 11)
+
+1. Select File > Swift Packages > Add Package Dependency. Enter `https://github.com/Alamofire/AlamofireNetworkActivityIndicator` in the "Choose Package Repository" dialog.
+2. In the next page, specify the version resolving rule as "Up to Next Major" with "3.0.0-beta.4" as its earliest version.
+3. After Xcode checking out the source and resolving the version, you can choose the "AlamofireNetworkActivityIndicator" library and add it to your app target.
+
 ### Manually
 
 If you prefer not to use either of the aforementioned dependency managers, you can integrate AlamofireNetworkActivityIndicator into your project manually.


### PR DESCRIPTION
### Issue Link :link:
Close #59 

### Goals :soccer:
SPM support for XCode 11 iOS projects.

### Implementation Details :construction:
XCode 11 introduce SPM support (for iOS project including). This PR will add `Package.swift` file as a requirement for it.

### Testing Details :mag:
Please note that I updated README.md file with an upcoming version tag. I don't know your release plans and set version to `3.0.0-beta.4`. Please reply what version I should set there.
