### PR TITLE
Ignore Carthage directory, update resolved.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,4 +36,4 @@ playground.xcworkspace
 .build/
 
 # Carthage
-Carthage/Build
+Carthage

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" "5.0.0"
+github "Alamofire/Alamofire" "5.0.2"


### PR DESCRIPTION
### Issue Link :link:
Fixes #64.

### Goals :soccer:
This PR adds the Carthage directory to the `.gitignore` file, as SPM checks out the submodule every time it checks out the repo. 

### Implementation Details :construction:
This simply ensures that the directory, already removed in a direct commit, doesn't come back.
