### PR TITLE
Require Swift 5.1.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,11 @@ on:
       - hotfix
   pull_request:
     branches: 
-      - master
-      - hotfix
+      - '*'
 
 jobs:
-  iOS:
-    name: Test iOS 
+  iOS_5_1:
+    name: Test iOS (5.1)
     runs-on: macOS-latest
     env: 
       DEVELOPER_DIR: /Applications/Xcode_11.3.1.app/Contents/Developer
@@ -21,8 +20,24 @@ jobs:
         destination: ["OS=13.3,name=iPhone 11 Pro"]
     steps:
       - name: Checkout
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
       - name: Dependencies
         run: carthage bootstrap --no-use-binaries --platform iOS
       - name: iOS
         run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "AlamofireNetworkActivityIndicator.xcodeproj" -scheme "AlamofireNetworkActivityIndicator" -destination "${{ matrix.destination }}" clean test | xcpretty
+  iOS_5_2:
+    name: Test iOS (5.2)
+    runs-on: macOS-latest
+    env: 
+      DEVELOPER_DIR: /Applications/Xcode_11.4.app/Contents/Developer
+    strategy:
+      matrix:
+        destination: ["OS=13.4,name=iPhone 11 Pro"]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Dependencies
+        run: carthage bootstrap --no-use-binaries --platform iOS
+      - name: iOS
+        run: set -o pipefail && env NSUnbufferedIO=YES xcodebuild -project "AlamofireNetworkActivityIndicator.xcodeproj" -scheme "AlamofireNetworkActivityIndicator" -destination "${{ matrix.destination }}" clean test | xcpretty
+  

--- a/.swiftformat
+++ b/.swiftformat
@@ -2,7 +2,7 @@
 
 --symlinks ignore
 --exclude Carthage
---swiftversion 5
+--swiftversion 5.1
 
 # rules
 --disable andOperator

--- a/AlamofireNetworkActivityIndicator.podspec
+++ b/AlamofireNetworkActivityIndicator.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'AlamofireNetworkActivityIndicator'
-  s.version = '3.0.1'
+  s.version = '3.1.0'
   s.license = 'MIT'
   s.summary = 'Controls the visibility of the network activity indicator on iOS using Alamofire'
   s.homepage = 'https://github.com/Alamofire/AlamofireNetworkActivityIndicator'
@@ -13,7 +13,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '10.0'
 
-  s.swift_versions = ['5.0', '5.1']
+  s.swift_versions = ['5.1', '5.2']
 
-  s.dependency 'Alamofire', '~> 5.0'
+  s.dependency 'Alamofire', '~> 5.1'
 end

--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "Alamofire/Alamofire" ~> 5.0
+github "Alamofire/Alamofire" ~> 5.1

--- a/Package.swift
+++ b/Package.swift
@@ -1,10 +1,34 @@
 // swift-tools-version:5.1
+//
+//  Package.swift
+//
+//  Copyright (c) 2020 Alamofire Software Foundation (http://alamofire.org/)
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+//
+
 import PackageDescription
 
 let package = Package(name: "AlamofireNetworkActivityIndicator",
                       platforms: [.iOS(.v10)],
                       products: [.library(name: "AlamofireNetworkActivityIndicator", targets: ["AlamofireNetworkActivityIndicator"])],
-                      dependencies: [.package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.0.0")],
+                      dependencies: [.package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.1.0")],
                       targets: [.target(name: "AlamofireNetworkActivityIndicator",
                                         dependencies: ["Alamofire"],
                                         path: "Source")])

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Controls the visibility of the network activity indicator on iOS using Alamofire
 ## Requirements
 
 - iOS 10.0+
-- Xcode 10.2+
-- Swift 5.0+
+- Xcode 11+
+- Swift 5.1+
 
 ## Dependencies
 
@@ -41,7 +41,7 @@ Controls the visibility of the network activity indicator on iOS using Alamofire
 [CocoaPods](https://cocoapods.org) is a dependency manager for Cocoa projects. For usage and installation instructions, visit their website. To integrate Alamofire into your Xcode project using CocoaPods, specify it in your `Podfile`:
 
 ```ruby
-pod 'AlamofireNetworkActivityIndicator', '~> 3.0'
+pod 'AlamofireNetworkActivityIndicator', '~> 3.1'
 ```
 
 ### Carthage
@@ -49,13 +49,13 @@ pod 'AlamofireNetworkActivityIndicator', '~> 3.0'
 [Carthage](https://github.com/Carthage/Carthage) is a decentralized dependency manager that builds your dependencies and provides you with binary frameworks. To integrate Alamofire into your Xcode project using Carthage, specify it in your `Cartfile`:
 
 ```ogdl
-github "Alamofire/AlamofireNetworkActivityIndicator" ~> 3.0
+github "Alamofire/AlamofireNetworkActivityIndicator" ~> 3.1
 ```
 
 ### Swift Package Manager (requires Xcode 11)
 
 1. Select File > Swift Packages > Add Package Dependency. Enter `https://github.com/Alamofire/AlamofireNetworkActivityIndicator` in the "Choose Package Repository" dialog.
-2. In the next page, specify the version resolving rule as "Up to Next Major" with "3.0.0" as its earliest version.
+2. In the next page, specify the version resolving rule as "Up to Next Major" with "3.1.0" as its earliest version.
 3. After Xcode checking out the source and resolving the version, you can choose the "AlamofireNetworkActivityIndicator" library and add it to your app target.
 
 ### Manually


### PR DESCRIPTION
### Goals :soccer:
This PR updates to require Swift 5.1 to match Alamofire and AlamofireImage.

### Implementation Details :construction:
No actual code changes required.
