### PR TITLE
[SPM] package.swift: add platform .macOS to match Alamofire

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@
 import PackageDescription
 
 let package = Package(name: "AlamofireNetworkActivityIndicator",
-                      platforms: [.iOS(.v10)],
+                      platforms: [.iOS(.v10), .macOS(.v10_12)],
                       products: [.library(name: "AlamofireNetworkActivityIndicator", targets: ["AlamofireNetworkActivityIndicator"])],
                       dependencies: [.package(url: "https://github.com/Alamofire/Alamofire.git", from: "5.1.0")],
                       targets: [.target(name: "AlamofireNetworkActivityIndicator",


### PR DESCRIPTION
Avoid the following issue with SPM: https://github.com/Alamofire/AlamofireNetworkActivityIndicator/issues/71

> error: the library 'AlamofireNetworkActivityIndicator' requires macos 10.10, but depends on the product 'Alamofire' which requires macos 10.12; consider changing the library 'AlamofireNetworkActivityIndicator' to require macos 10.12 or later, or the product 'Alamofire' to require macos 10.10 or earlier.
